### PR TITLE
Append posix to 'path' requires so that restberry can work on Windows.

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1,6 +1,6 @@
 var _ = require('underscore');
 var errors = require('restberry-errors');
-var path = require('path');
+var path = require('path').posix;
 var qs = require('qs');
 var RestberryObj = require('./obj');
 var RestberryObjs = require('./objs');

--- a/lib/obj.js
+++ b/lib/obj.js
@@ -1,6 +1,6 @@
 var _ = require('underscore');
 var errors = require('restberry-errors');
-var path = require('path');
+var path = require('path').posix;
 var utils = require('restberry-utils');
 
 function RestberryObj(model, data, fieldName) {

--- a/lib/router.js
+++ b/lib/router.js
@@ -1,7 +1,7 @@
 var _ = require('underscore');
 var errors = require('restberry-errors');
 var logger = require('restberry-logger');
-var path = require('path');
+var path = require('path').posix;
 var util = require('util');
 var utils = require('restberry-utils');
 


### PR DESCRIPTION
When using restberry on Windows path use '\' separator for join method so the path looks like /api/v1\cities\:id which causes a RegExp error on launch.

Appending posix forces path to use / as separator for join method