### PR TITLE
Added check for path.posix, so restberry can still work on node version prior to 0.12

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1,6 +1,6 @@
 var _ = require('underscore');
 var errors = require('restberry-errors');
-var path = require('path');
+var path = require('path').posix || require('path');
 var qs = require('qs');
 var RestberryObj = require('./obj');
 var RestberryObjs = require('./objs');

--- a/lib/obj.js
+++ b/lib/obj.js
@@ -1,6 +1,6 @@
 var _ = require('underscore');
 var errors = require('restberry-errors');
-var path = require('path');
+var path = require('path').posix || require('path');
 var utils = require('restberry-utils');
 
 function RestberryObj(model, data, fieldName) {

--- a/lib/router.js
+++ b/lib/router.js
@@ -1,7 +1,7 @@
 var _ = require('underscore');
 var errors = require('restberry-errors');
 var logger = require('restberry-logger');
-var path = require('path');
+var path = require('path').posix || require('path');
 var util = require('util');
 var utils = require('restberry-utils');
 


### PR DESCRIPTION
Added check for path.posix, so restberry can still work on node version prior to 0.12

To run restberry on Windows you will have to use node >= 0.12.